### PR TITLE
Session middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ if (!isNode) {
       cb.call(arguments)
     })
   }
+  process.version = '7.5.0';
 }
 
 function VineHill() {
@@ -51,7 +52,8 @@ function VineHill() {
           removeListener: function noop(){},
           unpipe: function (){
             response.status(404).end()
-          }
+          },
+          resume: function noop() {}
         };
 
         var headers = {};
@@ -87,9 +89,7 @@ function VineHill() {
             statusCode = status;
             return this;
           },
-          writeHead: function() {
-            console.log('WRITE HEAD', arguments)
-          }
+          writeHead: function noop() {}
         };
 
         if (before === 'http') {
@@ -125,7 +125,8 @@ function VineHill() {
               statusText: statusCodes[statusCode.toString()],
               statusCode: statusCode,
               headers: headers,
-              body: stream
+              body: stream,
+              url: req.url
             });
           }
         }
@@ -159,7 +160,8 @@ function VineHill() {
               statusText: statusCodes[statusCode.toString()],
               statusCode: statusCode,
               headers: headers,
-              body: body.join('')
+              body: body.join(''),
+              url: req.url
             });
           }
         }
@@ -178,6 +180,10 @@ function VineHill() {
   }
   require('httpism/browser').removeMiddleware('vinehill');
   require('httpism/browser').insertMiddleware(makeMiddleware('send'));
+
+  var cookieMiddleware = require('httpism/middleware').cookies;
+  cookieMiddleware.before = 'vinehill'
+  require('httpism/browser').insertMiddleware(cookieMiddleware);
 }
 
 VineHill.prototype.add = function(host, app) {

--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ function VineHill() {
               this.setHeader('content-type', 'text/plain');
             }
 
+            if (!this.headWritten) {
+              this.headWritten = true;
+              this.writeHead(statusCode, headers);
+            }
             stream.push(chunk);
           }
 
@@ -139,6 +143,11 @@ function VineHill() {
 
             if (typeof chunk === 'string' && !this.get('content-type')) {
               this.setHeader('content-type', 'text/plain');
+            }
+
+            if (!this.headWritten) {
+              this.headWritten = true;
+              this.writeHead(statusCode, headers);
             }
             body.push(chunk)
           }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var window = require('global');
 var isNode = require('is-node');
 var statusCodes = require('builtin-status-codes/browser')
 var ReadableStream = require('stream').Readable;
+var urlUtils = require('url');
 
 if (!isNode) {
   var http = require('http');
@@ -23,6 +24,7 @@ function VineHill() {
   function makeMiddleware(before) {
     var vinehillMiddleware = function(req){
       var origin = self.getOrigin(req.url);
+      var reqUrl = urlUtils.parse(req.url);
       var requestApp = self.appDNS[origin];
       if (!requestApp) {
         throw new Error('No app exists to listen to requests for '+origin);
@@ -37,7 +39,8 @@ function VineHill() {
         bodyStream._read = function(){}
 
         var request = {
-          url: req.url,
+          url: reqUrl.path,
+          hostname: reqUrl.hostname,
           method: req.method,
           body: bodyStream,
           headers: req.headers,

--- a/index.js
+++ b/index.js
@@ -75,10 +75,9 @@ function VineHill() {
           bodyStream.push(null);
         }
 
-        var statusCode = 200;
-
         var response = {
           _removedHeader: {},
+          statusCode: 200,
           get: function(name){
             return headers[name.toLowerCase()];
           },
@@ -89,7 +88,7 @@ function VineHill() {
             headers[name.toLowerCase()] = value;
           },
           status: function(status) {
-            statusCode = status;
+            this.statusCode = status;
             return this;
           },
           writeHead: function noop() {}
@@ -115,7 +114,7 @@ function VineHill() {
 
             if (!this.headWritten) {
               this.headWritten = true;
-              this.writeHead(statusCode, headers);
+              this.writeHead(this.statusCode, headers);
             }
             stream.push(chunk);
           }
@@ -125,8 +124,8 @@ function VineHill() {
             stream.push(null)
 
             success({
-              statusText: statusCodes[statusCode.toString()],
-              statusCode: statusCode,
+              statusText: statusCodes[this.statusCode.toString()],
+              statusCode: this.statusCode,
               headers: headers,
               body: stream,
               url: req.url
@@ -151,7 +150,7 @@ function VineHill() {
 
             if (!this.headWritten) {
               this.headWritten = true;
-              this.writeHead(statusCode, headers);
+              this.writeHead(this.statusCode, headers);
             }
             body.push(chunk)
           }
@@ -160,8 +159,8 @@ function VineHill() {
             this.write(chunk, encoding)
 
             success({
-              statusText: statusCodes[statusCode.toString()],
-              statusCode: statusCode,
+              statusText: statusCodes[this.statusCode.toString()],
+              statusCode: this.statusCode,
               headers: headers,
               body: body.join(''),
               url: req.url

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chai": "3.5.0",
     "connect": "3.5.0",
     "express": "4.14.0",
+    "express-session": "^1.15.1",
     "helmet": "^3.4.0",
     "httpism": "^2.6.1",
     "karma": "^1.3.0",

--- a/test/virtualHttpSpec.js
+++ b/test/virtualHttpSpec.js
@@ -223,6 +223,24 @@ modulesToTest.forEach(httpism => {
     });
   });
 
+  it('can redirect', () => {
+    var app = express();
+    app.get('/some/file.json', (req, res) => {
+      res.redirect('/some/other.json')
+    });
+
+    app.get('/some/other.json', (req, res) => {
+      res.send('OK')
+    })
+
+    vineHill({'http://server1': app});
+
+    return httpism.get('/some/file.json').then(response => {
+      expect(response.statusCode).to.equal(200)
+      expect(response.url).to.equal('/some/other.json')
+    })
+  })
+
   describe('express middleware compatibility', () => {
     function setupWithMiddleware(addMiddlewareFn) {
       var app = express();

--- a/test/virtualHttpSpec.js
+++ b/test/virtualHttpSpec.js
@@ -269,9 +269,10 @@ modulesToTest.forEach(httpism => {
         })
       })
 
-      return httpism.get('/set-session').then(setResponse => {
+      var api = httpism.api('http://server1/', {cookies: true});
+      return api.get('/set-session').then(setResponse => {
         expect(setResponse.body).to.equal('OK');
-        return httpism.get('/get-session', {headers: {Cookie: setResponse.headers['set-cookie'].join('')}}).then(getResponse => {
+        return api.get('/get-session').then(getResponse => {
           expect(getResponse.body).to.equal('hello')
         })
       });


### PR DESCRIPTION
Convert response to writable stream
Add middleware to browser version to handle cookies and redirect following

These changes allow you to use the `express-session` and `helmet` middleware