### PR TITLE
log request/response objects using debug module

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,28 @@ httpism.get('http://weather.com/weather/london').then(response => {
 });
 ```
 
+# Logging
+
+Vinehill logs requests/responses using the excellent [debug](https://www.npmjs.com/package/debug) module
+To log in the console set the `DEBUG` env variable to `vinehill*` and then run your tests.
+
+For example:
+
+```
+DEBUG=vinehill* mocha
+```
+
+If you are using vinehill in a browser then you can enable logging by running this code in the console (or before vinehill is required)
+
+```js
+localStorage.debug = 'vinehill*'
+```
+You can further filter logging by replacing `vinehill*`:
+ - `vinehill` only logs a simplified `METHOD: URL STATUS => STATUSTEXT` eg. `PUT: http://server1/some/file.txt => 200 OK`
+- `vinehill:request` only log request objects
+- `vinehill:response` only log response objects
+- `vinehill*` log request, response and simplified version
+
 # Browser support
 
 * Chrome

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var isNode = require('is-node');
 var statusCodes = require('builtin-status-codes/browser')
 var urlUtils = require('url');
 var Stream = require('stream');
+var log = require('./log')
 
 if (!isNode) {
   var http = require('http');
@@ -36,6 +37,7 @@ function VineHill() {
       }
 
       return new Promise(function(success){
+        log.request(req)
         var request = new Stream.Readable();
 
         request.url = reqUrl.path
@@ -169,7 +171,11 @@ function VineHill() {
           }
         }
         requestApp.handle(request, response);
-      });
+      }).then(res => {
+        log.main(req.method.toUpperCase() + ': ' + req.url + ' => ' + res.statusCode + ' ' + res.statusText)
+        log.response(res)
+        return res
+      })
     };
 
     vinehillMiddleware.before = [before];

--- a/log.js
+++ b/log.js
@@ -29,18 +29,15 @@ function prepareForLogging(request) {
     statusText: request.statusText
   });
 }
+
 module.exports = {
-  debug: function(message) {
+  main: function(message) {
     debug(message)
   },
-
-  main: function(message) {
-    this.debug(message)
-  },
   request: function(req) {
-    this.debug(prepareForLogging(req))
+    debugRequest(prepareForLogging(req))
   },
   response: function(res) {
-    this.debug(prepareForLogging(res))
+    debugResponse(prepareForLogging(res))
   }
 }

--- a/log.js
+++ b/log.js
@@ -1,0 +1,46 @@
+var createDebug = require("debug");
+var debug = createDebug("vinehill");
+var debugResponse = createDebug("vinehill:response");
+var debugRequest = createDebug("vinehill:request");
+
+
+function isStream(body) {
+  return body !== undefined && typeof body.pipe === 'function';
+}
+
+
+function removeUndefined(obj) {
+  Object.keys(obj).map(function (key) {
+    if (typeof obj[key] === 'undefined') {
+      delete obj[key];
+    }
+  });
+
+  return obj;
+}
+
+function prepareForLogging(request) {
+  return removeUndefined({
+    method: request.method,
+    url: request.url,
+    headers: request.headers,
+    body: isStream(request.body)? '[Stream]': request.body,
+    statusCode: request.statusCode,
+    statusText: request.statusText
+  });
+}
+module.exports = {
+  debug: function(message) {
+    debug(message)
+  },
+
+  main: function(message) {
+    this.debug(message)
+  },
+  request: function(req) {
+    this.debug(prepareForLogging(req))
+  },
+  response: function(res) {
+    this.debug(prepareForLogging(res))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.15.2",
     "browserify": "^13.1.1",
     "chai": "3.5.0",
+    "chai-subset": "^1.5.0",
     "connect": "3.5.0",
     "express": "4.14.0",
     "express-session": "^1.15.1",
@@ -30,6 +31,7 @@
   },
   "dependencies": {
     "builtin-status-codes": "3.0.0",
+    "debug": "^2.6.3",
     "global": "4.3.1",
     "is-node": "1.0.2"
   },

--- a/test/fakeLogger.js
+++ b/test/fakeLogger.js
@@ -1,23 +1,24 @@
 var logger = require('../log')
+var originalMainLogger = logger.main
 var originalRequestLogger = logger.request
 var originalResponseLogger = logger.response
-var originalMainLogger = logger.main
 
 module.exports.start = () => {
+  var self = this
   this.requests = []
   this.responses = []
   this.main = []
 
-  logger.main = (req) => {
-    this.main.push(req)
+  logger.main = function(req) {
+    self.main.push(req)
     originalMainLogger.apply(logger, arguments)
   }
-  logger.request = (req) => {
-    this.requests.push(req)
+  logger.request = function (req) {
+    self.requests.push(req)
     originalRequestLogger.apply(logger, arguments)
   }
-  logger.response = (res) => {
-    this.responses.push(res)
+  logger.response = function (res) {
+    self.responses.push(res)
     originalResponseLogger.apply(logger, arguments)
   }
 }

--- a/test/fakeLogger.js
+++ b/test/fakeLogger.js
@@ -1,0 +1,30 @@
+var logger = require('../log')
+var originalRequestLogger = logger.request
+var originalResponseLogger = logger.response
+var originalMainLogger = logger.main
+
+module.exports.start = () => {
+  this.requests = []
+  this.responses = []
+  this.main = []
+
+  logger.main = (req) => {
+    this.main.push(req)
+    originalMainLogger.apply(logger, arguments)
+  }
+  logger.request = (req) => {
+    this.requests.push(req)
+    originalRequestLogger.apply(logger, arguments)
+  }
+  logger.response = (res) => {
+    this.responses.push(res)
+    originalResponseLogger.apply(logger, arguments)
+  }
+}
+
+
+module.exports.stop = () => {
+  logger.main = originalMainLogger
+  logger.request = originalRequestLogger
+  logger.response = originalResponseLogger
+}


### PR DESCRIPTION
# Logging

Vinehill logs requests/responses using the excellent [debug](https://www.npmjs.com/package/debug) module
To log in the console set the `DEBUG` env variable to `vinehill*` and then run your tests.

For example:

```
DEBUG=vinehill* mocha
```

If you are using vinehill in a browser then you can enable logging by running this code in the console (or before vinehill is required)

```js
localStorage.debug = 'vinehill*'
```
You can further filter logging by replacing `vinehill*`:
 - `vinehill` only logs a simplified `METHOD: URL STATUS => STATUSTEXT` eg. `PUT: http://server1/some/file.txt => 200 OK`
- `vinehill:request` only log request objects
- `vinehill:response` only log response objects
- `vinehill*` log request, response and simplified version 

![vinehill](https://cloud.githubusercontent.com/assets/144922/24428413/4b89ea60-1406-11e7-8355-605169ac8e72.png)
